### PR TITLE
79 add configenv instructions to readme

### DIFF
--- a/DBconfig.md
+++ b/DBconfig.md
@@ -1,0 +1,20 @@
+![image](https://github.com/ImanKahlila/ProjectHunt/assets/118192650/4c30e9e2-f8f7-475a-8a18-d5d397cfd98f)
+1. Create a new file named "config.env" within the config folder
+2. Add the PORT number of your choice
+3. Add your DB connection string from MongoDB Atlas
+4. Save the file
+5. Now npm start, and the server should run without any error
+
+[Get connection string](https://shields.io/](https://www.mongodb.com/basics/mongodb-connection-string#:~:text=How%20to%20get%20your%20MongoDB,connection%20string%20for%20your%20cluster.))
+
+<img src="https://github.com/ImanKahlila/ProjectHunt/assets/118192650/5f7e73e3-ab2f-4b6d-b56f-277282854b46" width="80%" />
+![image]()
+
+<img src="https://github.com/ImanKahlila/ProjectHunt/assets/118192650/327c9d9e-f372-4c29-bb47-e0093a78e1b0" width="80%" />
+
+
+Change connection password or add new DB user with own password
+
+<img src="https://github.com/ImanKahlila/ProjectHunt/assets/118192650/d33bfebe-c812-4b08-80a1-bf45b49dbea2" width="80%" />
+
+Paste this password in the DB connection string

--- a/README.md
+++ b/README.md
@@ -160,6 +160,9 @@ Install dependencies
   npm install
 ```
 
+Setup config.env file <a href="https://github.com/ImanKahlila/ProjectHunt/blob/79-add-configenv-instructions-to-readme/DBconfig.md">Details Here</a>
+![image](https://github.com/ImanKahlila/ProjectHunt/assets/118192650/4c30e9e2-f8f7-475a-8a18-d5d397cfd98f)
+
 Start the server
 
 ```bash


### PR DESCRIPTION
Added DBconfig.md (instructions) to repo and linked to it in the get started steps to avoid cluttering the main README too much